### PR TITLE
refactor: fix deprecation on configuration return

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -11,7 +11,7 @@ final class Configuration implements ConfigurationInterface
     /**
      * @inheritDoc
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         if (Kernel::MAJOR_VERSION < 4) { // @phpstan-ignore-line
             $treeBuilder = new TreeBuilder(); // @phpstan-ignore-line


### PR DESCRIPTION
With the Symfony profiler, I have this deprecation:
```
Method "Symfony\Component\Config\Definition\ConfigurationInterface::getConfigTreeBuilder()" might add "TreeBuilder" as a native return type declaration in the future. Do the same in implementation "BenTools\Shh\DependencyInjection\Configuration" now to avoid errors or add an explicit @return annotation to suppress this message.
```

So, I had the return `TreeBuilder` to prevent it.