### PR TITLE
chore: use `AsCommand` attribute and remove no longer maintained Symfony versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,20 +24,20 @@
   ],
   "require": {
     "php": ">=8.0",
-    "symfony/dependency-injection": "~4.0|~5.0|~6.0",
-    "symfony/console": "~4.0|~5.0|~6.0",
-    "symfony/config": "~4.0|~5.0|~6.0",
-    "symfony/http-kernel": "~4.0|~5.0|~6.0",
-    "symfony/filesystem": "~4.0|~5.0|~6.0",
+    "symfony/dependency-injection": "~5.4|~6.0",
+    "symfony/console": "~5.4|~6.0",
+    "symfony/config": "~5.4|~6.0",
+    "symfony/http-kernel": "~5.4|~6.0",
+    "symfony/filesystem": "~5.4|~6.0",
     "bentools/shh": "~1.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~7.0|~8.0",
     "squizlabs/php_codesniffer": "~3.7",
-    "symfony/var-dumper": "~4.0|~5.0|~6.0",
+    "symfony/var-dumper": "~5.4|~6.0",
     "php-coveralls/php-coveralls": "^2.1",
     "phpstan/phpstan": "^1.0",
-    "symfony/framework-bundle": "~4.0|~5.0|~6.0",
+    "symfony/framework-bundle": "~5.4|~6.0",
     "nyholm/symfony-bundle-test": "^1.4",
     "bentools/cartesian-product": "^1.3",
     "thecodingmachine/safe": "^1.0"

--- a/src/Command/ChangePassphraseCommand.php
+++ b/src/Command/ChangePassphraseCommand.php
@@ -3,19 +3,19 @@
 namespace BenTools\Shh\Command;
 
 use BenTools\Shh\Shh;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\HttpKernel\Kernel;
 
+#[AsCommand(
+    name: 'shh:change:passphrase',
+)]
 final class ChangePassphraseCommand extends Command
 {
-    protected static $defaultName = 'shh:change:passphrase';
-
     /**
      * @var Filesystem
      */

--- a/src/Command/CheckCommand.php
+++ b/src/Command/CheckCommand.php
@@ -3,16 +3,18 @@
 namespace BenTools\Shh\Command;
 
 use BenTools\Shh\Shh;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+#[AsCommand(
+    name: 'shh:check',
+)]
 final class CheckCommand extends Command
 {
-    protected static $defaultName = 'shh:check';
-
     /**
      * @var string
      */

--- a/src/Command/DecryptCommand.php
+++ b/src/Command/DecryptCommand.php
@@ -3,16 +3,18 @@
 namespace BenTools\Shh\Command;
 
 use BenTools\Shh\Shh;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+#[AsCommand(
+    name: 'shh:decrypt',
+)]
 final class DecryptCommand extends Command
 {
-    protected static $defaultName = 'shh:decrypt';
-
     /**
      * @var Shh
      */

--- a/src/Command/EncryptCommand.php
+++ b/src/Command/EncryptCommand.php
@@ -3,16 +3,18 @@
 namespace BenTools\Shh\Command;
 
 use BenTools\Shh\Shh;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+#[AsCommand(
+    name: 'shh:encrypt',
+)]
 final class EncryptCommand extends Command
 {
-    protected static $defaultName = 'shh:encrypt';
-
     /**
      * @var Shh
      */

--- a/src/Command/GenerateKeyPairCommand.php
+++ b/src/Command/GenerateKeyPairCommand.php
@@ -3,6 +3,7 @@
 namespace BenTools\Shh\Command;
 
 use BenTools\Shh\Shh;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -10,10 +11,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Filesystem\Filesystem;
 
+#[AsCommand(
+    name: 'shh:generate:keys',
+)]
 final class GenerateKeyPairCommand extends Command
 {
-    protected static $defaultName = 'shh:generate:keys';
-
     /**
      * @var string
      */

--- a/src/Command/RegisterSecretCommand.php
+++ b/src/Command/RegisterSecretCommand.php
@@ -3,6 +3,7 @@
 namespace BenTools\Shh\Command;
 
 use BenTools\Shh\SecretStorage\SecretStorageInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -10,10 +11,11 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+#[AsCommand(
+    name: 'shh:register:secret',
+)]
 final class RegisterSecretCommand extends Command
 {
-    protected static $defaultName = 'shh:register:secret';
-
     /**
      * @var SecretStorageInterface
      */

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -4,7 +4,6 @@ namespace BenTools\Shh\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
-use Symfony\Component\HttpKernel\Kernel;
 
 final class Configuration implements ConfigurationInterface
 {
@@ -13,15 +12,9 @@ final class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder(): TreeBuilder
     {
-        if (Kernel::MAJOR_VERSION < 4) { // @phpstan-ignore-line
-            $treeBuilder = new TreeBuilder(); // @phpstan-ignore-line
-            $rootNode = $treeBuilder->root('shh'); // @phpstan-ignore-line
-            $configDir = '%kernel.project_dir%/app/config/shh';
-        } else {
-            $treeBuilder = new TreeBuilder('shh');
-            $rootNode = $treeBuilder->getRootNode();
-            $configDir = '%kernel.project_dir%/config/shh';
-        }
+        $treeBuilder = new TreeBuilder('shh');
+        $rootNode = $treeBuilder->getRootNode();
+        $configDir = '%kernel.project_dir%/config/shh';
 
         // @phpstan-ignore-next-line
         $rootNode

--- a/src/DependencyInjection/ShhExtension.php
+++ b/src/DependencyInjection/ShhExtension.php
@@ -6,7 +6,6 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
-use Symfony\Component\HttpKernel\Kernel;
 
 final class ShhExtension extends Extension
 {
@@ -33,10 +32,6 @@ final class ShhExtension extends Extension
 
     private function guessKeysDirectory(ContainerBuilder $container): string
     {
-        if (Kernel::MAJOR_VERSION < 4) { // @phpstan-ignore-line
-            return $container->getParameter('kernel.project_dir') . '/app/config/shh'; // @phpstan-ignore-line
-        }
-
         return $container->getParameter('kernel.project_dir') . '/config/shh'; // @phpstan-ignore-line
     }
 }


### PR DESCRIPTION
Hi @bpolaszek :slightly_smiling_face: ,

I removed the no longer maintained Symfony versions and the related conditions.

The `$defaultName` property is deprecated since Symfony version 6.1 (see https://github.com/symfony/symfony/pull/45361). I replaced by `AsCommand` attribute instead.