### PR TITLE
ci: add PHP versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
         php:
           - 8.0
           - 8.1
+          - 8.2
+          - 8.3
+          - 8.4
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
This PR adds on the CI:
- PHP 8.2
- PHP 8.3
- PHP 8.4